### PR TITLE
Replacing `optparse` with `argparse`

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -199,7 +199,6 @@ def main(args=None):
             import __builtin__ as builtins
         builtins.__dict__['profile'] = prof
 
-    print(options.script_file)
     script_file = find_script(options.script_file)
     __file__ = script_file
     __name__ = '__main__'


### PR DESCRIPTION
Hello,

Since optparse is deprecated, so I did a few modifications to the code to use argparse.
The only differences are that with argparse the order of the parameters does not matter.
I added an argument called "script_file"  _without_ any minus-option (instead of a "-i/--input script_file"),
to have the same usage as optparse.

Regards
