### PR TITLE
kernprof: better support following forks

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -225,8 +225,9 @@ def main(args=None):
         except (KeyboardInterrupt, SystemExit):
             pass
     finally:
-        prof.dump_stats(options.outfile)
-        print('Wrote profile results to %s' % options.outfile)
+        pid_outfile = '{0}.{1}'.format(options.outfile, os.getpid())
+        prof.dump_stats(pid_outfile)
+        print('Wrote profile results to %s' % pid_outfile)
         if options.view:
             prof.print_stats()
 


### PR DESCRIPTION
kernprof itself has no problem following forks, but happily clobbers the output of exited processes.  by tagging each profiler dump with it's PID, we can avoid this clobbering.
