### PR TITLE
Update for compatibility with IPython 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.2"
   - "2.7"
 install:
-  - pip install --install-option='--no-cython-compile' -r dev_requirements.txt
+  - pip install -r dev_requirements.txt
   - python setup.py develop
 script:
   - python -m unittest discover -v tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ script:
   - python -m unittest discover -v tests
 notifications:
   email:
+      - brett.olsen+travis-ci@gmail.com
       - robert.kern+travis-ci@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.3"
   - "2.7"
 install:
-  - pip install --install-option='--no-cython-compile' -r dev_requirements.txt
-  - pip install ipython
+  - pip install --install-option='--no-cython-compile' Cython
+  - pip install -r dev_requirements.txt
   - python setup.py develop
 script:
   - python -m unittest discover -v tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "3.4"
   - "3.3"
-  - "3.2"
   - "2.7"
 install:
-  - pip install -r dev_requirements.txt
+  - pip install --install-option='--no-cython-compile' -r dev_requirements.txt
+  - pip install ipython
   - python setup.py develop
 script:
   - python -m unittest discover -v tests

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
 	@echo 'Just some tools to help me make releases. Nothing for users.'
 
-index.html: README.txt
-	rst2html.py README.txt index.html
+index.html: README.rst
+	rst2html.py README.rst index.html
 
 pypi-site-docs.zip: index.html kernprof.py LICENSE.txt
 	zip -r $@ $?

--- a/README.rst
+++ b/README.rst
@@ -355,6 +355,10 @@ Bugs and pull requested can be submitted on GitHub_.
 Changes
 =======
 
+2.0
+~~~
+* BUG: Added support for IPython 5.0+, removed support for IPython <=0.12
+
 1.1
 ~~~
 * BUG: Read source files as bytes.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ They are available under a `BSD license`_.
 Installation
 ============
 
-Releases of `line_profiler` can be installed using pip_::
+Releases of `line_profiler` can be installed using pip::
 
     $ pip install line_profiler
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,2 @@
+ipython
 Cython

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,2 @@
 Cython
+IPython>=0.13

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
 ipython
-Cython
+Cython --install-option='--no-cython-compile'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,1 @@
-ipython
-Cython --install-option='--no-cython-compile'
+Cython

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -17,6 +17,8 @@ import optparse
 import os
 import sys
 
+from IPython.core.magic import (Magics, magics_class, line_magic)
+
 from _line_profiler import LineProfiler as CLineProfiler
 
 # Python 2/3 compatibility utils
@@ -226,150 +228,153 @@ def show_text(stats, unit, stream=None, stripzeros=False):
     for (fn, lineno, name), timings in sorted(stats.items()):
         show_func(fn, lineno, name, stats[fn, lineno, name], unit, stream=stream, stripzeros=stripzeros)
 
-# A %lprun magic for IPython.
-def magic_lprun(self, parameter_s=''):
-    """ Execute a statement under the line-by-line profiler from the
-    line_profiler module.
+@magics_class
+class LineProfilerMagics(Magics):
 
-    Usage:
-      %lprun -f func1 -f func2 <statement>
+    @line_magic
+    def lprun(self, parameter_s=''):
+        """ Execute a statement under the line-by-line profiler from the
+        line_profiler module.
 
-    The given statement (which doesn't require quote marks) is run via the
-    LineProfiler. Profiling is enabled for the functions specified by the -f
-    options. The statistics will be shown side-by-side with the code through the
-    pager once the statement has completed.
+        Usage:
+          %lprun -f func1 -f func2 <statement>
 
-    Options:
+        The given statement (which doesn't require quote marks) is run via the
+        LineProfiler. Profiling is enabled for the functions specified by the -f
+        options. The statistics will be shown side-by-side with the code through the
+        pager once the statement has completed.
 
-    -f <function>: LineProfiler only profiles functions and methods it is told
-    to profile.  This option tells the profiler about these functions. Multiple
-    -f options may be used. The argument may be any expression that gives
-    a Python function or method object. However, one must be careful to avoid
-    spaces that may confuse the option parser. Additionally, functions defined
-    in the interpreter at the In[] prompt or via %run currently cannot be
-    displayed.  Write these functions out to a separate file and import them.
+        Options:
 
-    -m <module>: Get all the functions/methods in a module
+        -f <function>: LineProfiler only profiles functions and methods it is told
+        to profile.  This option tells the profiler about these functions. Multiple
+        -f options may be used. The argument may be any expression that gives
+        a Python function or method object. However, one must be careful to avoid
+        spaces that may confuse the option parser. Additionally, functions defined
+        in the interpreter at the In[] prompt or via %run currently cannot be
+        displayed.  Write these functions out to a separate file and import them.
 
-    One or more -f or -m options are required to get any useful results.
+        -m <module>: Get all the functions/methods in a module
 
-    -D <filename>: dump the raw statistics out to a pickle file on disk. The
-    usual extension for this is ".lprof". These statistics may be viewed later
-    by running line_profiler.py as a script.
+        One or more -f or -m options are required to get any useful results.
 
-    -T <filename>: dump the text-formatted statistics with the code side-by-side
-    out to a text file.
+        -D <filename>: dump the raw statistics out to a pickle file on disk. The
+        usual extension for this is ".lprof". These statistics may be viewed later
+        by running line_profiler.py as a script.
 
-    -r: return the LineProfiler object after it has completed profiling.
+        -T <filename>: dump the text-formatted statistics with the code side-by-side
+        out to a text file.
 
-    -s: strip out all entries from the print-out that have zeros.
-    """
-    # Local imports to avoid hard dependency.
-    from distutils.version import LooseVersion
-    import IPython
-    ipython_version = LooseVersion(IPython.__version__)
-    if ipython_version < '0.11':
-        from IPython.genutils import page
-        from IPython.ipstruct import Struct
-        from IPython.ipapi import UsageError
-    else:
-        from IPython.core.page import page
-        from IPython.utils.ipstruct import Struct
-        from IPython.core.error import UsageError
+        -r: return the LineProfiler object after it has completed profiling.
 
-    # Escape quote markers.
-    opts_def = Struct(D=[''], T=[''], f=[], m=[])
-    parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
-    opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:', list_all=True)
-    opts.merge(opts_def)
+        -s: strip out all entries from the print-out that have zeros.
+        """
+        # Local imports to avoid hard dependency.
+        from distutils.version import LooseVersion
+        import IPython
+        ipython_version = LooseVersion(IPython.__version__)
+        if ipython_version < '0.11':
+            from IPython.genutils import page
+            from IPython.ipstruct import Struct
+            from IPython.ipapi import UsageError
+        else:
+            from IPython.core.page import page
+            from IPython.utils.ipstruct import Struct
+            from IPython.core.error import UsageError
 
-    global_ns = self.shell.user_global_ns
-    local_ns = self.shell.user_ns
+        # Escape quote markers.
+        opts_def = Struct(D=[''], T=[''], f=[], m=[])
+        parameter_s = parameter_s.replace('"', r'\"').replace("'", r"\'")
+        opts, arg_str = self.parse_options(parameter_s, 'rsf:m:D:T:', list_all=True)
+        opts.merge(opts_def)
 
-    # Get the requested functions.
-    funcs = []
-    for name in opts.f:
+        global_ns = self.shell.user_global_ns
+        local_ns = self.shell.user_ns
+
+        # Get the requested functions.
+        funcs = []
+        for name in opts.f:
+            try:
+                funcs.append(eval(name, global_ns, local_ns))
+            except Exception as e:
+                raise UsageError('Could not find function %r.\n%s: %s' % (name,
+                    e.__class__.__name__, e))
+
+        profile = LineProfiler(*funcs)
+
+        # Get the modules, too
+        for modname in opts.m:
+            try:
+                mod = __import__(modname, fromlist=[''])
+                profile.add_module(mod)
+            except Exception as e:
+                raise UsageError('Could not find module %r.\n%s: %s' % (modname,
+                    e.__class__.__name__, e))
+
+        # Add the profiler to the builtins for @profile.
+        if PY3:
+            import builtins
+        else:
+            import __builtin__ as builtins
+
+        if 'profile' in builtins.__dict__:
+            had_profile = True
+            old_profile = builtins.__dict__['profile']
+        else:
+            had_profile = False
+            old_profile = None
+        builtins.__dict__['profile'] = profile
+
         try:
-            funcs.append(eval(name, global_ns, local_ns))
-        except Exception as e:
-            raise UsageError('Could not find function %r.\n%s: %s' % (name,
-                e.__class__.__name__, e))
+            try:
+                profile.runctx(arg_str, global_ns, local_ns)
+                message = ''
+            except SystemExit:
+                message = """*** SystemExit exception caught in code being profiled."""
+            except KeyboardInterrupt:
+                message = ("*** KeyboardInterrupt exception caught in code being "
+                    "profiled.")
+        finally:
+            if had_profile:
+                builtins.__dict__['profile'] = old_profile
 
-    profile = LineProfiler(*funcs)
+        # Trap text output.
+        stdout_trap = StringIO()
+        profile.print_stats(stdout_trap, stripzeros='s' in opts)
+        output = stdout_trap.getvalue()
+        output = output.rstrip()
 
-    # Get the modules, too
-    for modname in opts.m:
-        try:
-            mod = __import__(modname, fromlist=[''])
-            profile.add_module(mod)
-        except Exception as e:
-            raise UsageError('Could not find module %r.\n%s: %s' % (modname,
-                e.__class__.__name__, e))
+        if ipython_version < '0.11':
+            page(output, screen_lines=self.shell.rc.screen_length)
+        else:
+            page(output)
+        print(message, end="")
 
-    # Add the profiler to the builtins for @profile.
-    if PY3:
-        import builtins
-    else:
-        import __builtin__ as builtins
+        dump_file = opts.D[0]
+        if dump_file:
+            profile.dump_stats(dump_file)
+            print('\n*** Profile stats pickled to file %r. %s' % (
+                dump_file, message))
 
-    if 'profile' in builtins.__dict__:
-        had_profile = True
-        old_profile = builtins.__dict__['profile']
-    else:
-        had_profile = False
-        old_profile = None
-    builtins.__dict__['profile'] = profile
+        text_file = opts.T[0]
+        if text_file:
+            pfile = open(text_file, 'w')
+            pfile.write(output)
+            pfile.close()
+            print('\n*** Profile printout saved to text file %r. %s' % (
+                text_file, message))
 
-    try:
-        try:
-            profile.runctx(arg_str, global_ns, local_ns)
-            message = ''
-        except SystemExit:
-            message = """*** SystemExit exception caught in code being profiled."""
-        except KeyboardInterrupt:
-            message = ("*** KeyboardInterrupt exception caught in code being "
-                "profiled.")
-    finally:
-        if had_profile:
-            builtins.__dict__['profile'] = old_profile
+        return_value = None
+        if 'r' in opts:
+            return_value = profile
 
-    # Trap text output.
-    stdout_trap = StringIO()
-    profile.print_stats(stdout_trap, stripzeros='s' in opts)
-    output = stdout_trap.getvalue()
-    output = output.rstrip()
-
-    if ipython_version < '0.11':
-        page(output, screen_lines=self.shell.rc.screen_length)
-    else:
-        page(output)
-    print(message, end="")
-
-    dump_file = opts.D[0]
-    if dump_file:
-        profile.dump_stats(dump_file)
-        print('\n*** Profile stats pickled to file %r. %s' % (
-            dump_file, message))
-
-    text_file = opts.T[0]
-    if text_file:
-        pfile = open(text_file, 'w')
-        pfile.write(output)
-        pfile.close()
-        print('\n*** Profile printout saved to text file %r. %s' % (
-            text_file, message))
-
-    return_value = None
-    if 'r' in opts:
-        return_value = profile
-
-    return return_value
+        return return_value
 
 
 def load_ipython_extension(ip):
     """ API for IPython to recognize this module as an IPython extension.
     """
-    ip.define_magic('lprun', magic_lprun)
+    ip.register_magics(LineProfilerMagics)
 
 
 def load_stats(filename):

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -335,10 +335,7 @@ class LineProfilerMagics(Magics):
         output = stdout_trap.getvalue()
         output = output.rstrip()
 
-        if ipython_version < '0.11':
-            page(output, screen_lines=self.shell.rc.screen_length)
-        else:
-            page(output)
+        page(output)
         print(message, end="")
 
         dump_file = opts.D[0]

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -18,6 +18,9 @@ import os
 import sys
 
 from IPython.core.magic import (Magics, magics_class, line_magic)
+from IPython.core.page import page
+from IPython.utils.ipstruct import Struct
+from IPython.core.error import UsageError
 
 from _line_profiler import LineProfiler as CLineProfiler
 
@@ -269,18 +272,6 @@ class LineProfilerMagics(Magics):
 
         -s: strip out all entries from the print-out that have zeros.
         """
-        # Local imports to avoid hard dependency.
-        from distutils.version import LooseVersion
-        import IPython
-        ipython_version = LooseVersion(IPython.__version__)
-        if ipython_version < '0.11':
-            from IPython.genutils import page
-            from IPython.ipstruct import Struct
-            from IPython.ipapi import UsageError
-        else:
-            from IPython.core.page import page
-            from IPython.utils.ipstruct import Struct
-            from IPython.core.error import UsageError
 
         # Escape quote markers.
         opts_def = Struct(D=[''], T=[''], f=[], m=[])

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,13 @@ function-level profiling tools in the Python standard library.
 
 setup(
     name = 'line_profiler',
-    version = '1.0',
+    version = '2.0',
     author = 'Robert Kern',
     author_email = 'robert.kern@enthought.com',
     description = 'Line-by-line profiler.',
     long_description = long_description,
     url = 'https://github.com/rkern/line_profiler',
+    download_url = 'https://github.com/rkern/line_profiler/tarball/2.0',
     ext_modules = [
         Extension('_line_profiler',
                   sources=[line_profiler_source, 'timers.c', 'unset_trace.c'],
@@ -48,6 +49,7 @@ setup(
         ),
     ],
     license = "BSD",
+    keywords = ['timing', 'timer', 'profiling', 'profiler', 'line_profiler'],
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -70,5 +72,8 @@ setup(
             'kernprof=kernprof:main',
         ],
     },
+    install_requires = [
+        'IPython>=0.13',
+    ],
     cmdclass = cmdclass,
 )


### PR DESCRIPTION
Replaces the depreciated ip.define_magic() method with ip.register_magics() and some modifications to handle the different API required.

Also tested with IPython 4.1.1.  I don't know how far back the ip.register_magics() method goes, so I'm not sure how far back it's compatible.

Edit:  Apparently the new API was included as far back as 0.13, and the old API was finally removed in 5.0.  So removing support for the old API entirely is pretty unlikely to cause problems.