### PR TITLE
Allow user to add directories to the Python path.

### DIFF
--- a/kernprof.py
+++ b/kernprof.py
@@ -166,6 +166,8 @@ def main(args=None):
         help="Code to execute before the code to profile")
     parser.add_option('-v', '--view', action='store_true',
         help="View the results of the profile in addition to saving it.")
+    parser.add_option('-p', '--pythonpath', action='append',
+        help="Extra additions to PYTHONPATH.", default=None)
 
     if not sys.argv[1:]:
         parser.print_usage()
@@ -213,6 +215,11 @@ def main(args=None):
     # Make sure the script's directory is on sys.path instead of just
     # kernprof.py's.
     sys.path.insert(0, os.path.dirname(script_file))
+
+    # Add user-provided directories to sys.path.
+    if options.pythonpath is not None:
+        for path in options.pythonpath:
+            sys.path.insert(0, path)
 
     try:
         try:


### PR DESCRIPTION
This allows us to profile scripts that are located within a package hierarchy.
Multiple directories may be added, via either the short argument -p or long
argument --pythonpath.

Usage:
`kernprof <other options> -p dir1 [-p dir2 -p dir3 ...] script_to_profile.py`

Ex:
Script `foo/bar/script.py`, with directory structure:
```
base/
|---foo/
    |---__init__.py
    |---bar/
        |---__init__.py
        |---script.py
```
Script can normally be run via `python -m foo.bar.script` or `python foo/bar/script.py`.

To run kernprof:
From base:

    kernprof -l -v -p . foo/bar/script.py