### PR TITLE
BUG: Switched to new way of registering ipython magics

### DIFF
--- a/line_profiler.py
+++ b/line_profiler.py
@@ -369,7 +369,11 @@ def magic_lprun(self, parameter_s=''):
 def load_ipython_extension(ip):
     """ API for IPython to recognize this module as an IPython extension.
     """
-    ip.define_magic('lprun', magic_lprun)
+    if hasattr(ip, 'define_magic'):
+        ip.define_magic('lprun', magic_lprun)
+        return
+
+    ip.register_magic_function(magic_lprun, magic_kind='line', magic_name='lprun')
 
 
 def load_stats(filename):


### PR DESCRIPTION
Hi Robert,

Thanks for the awesome package, it's been a lifesaver on many occasions!

This is a minor change, implementing the new way of registering ipython magics. Namely, `get_ipython().define_magic(...)` was apparently deprecated. The new way uses `get_ipython().register_magic_function(...)` instead. I did leave the old one in for backward compatibility.

Cheers,
-Kris