### PR TITLE
Get support for new 3.5 Python coroutines

### DIFF
--- a/line_profiler.py
+++ b/line_profiler.py
@@ -53,8 +53,6 @@ else:
 # ============================================================
 
 CO_GENERATOR = 0x0020
-
-
 def is_generator(f):
     """ Return True if a function is a generator.
     """
@@ -71,7 +69,7 @@ class LineProfiler(CLineProfiler):
         it on function exit.
         """
         self.add_function(func)
-        if PY35 and is_coroutine(func):
+        if is_coroutine(func):
             wrapper = self.wrap_coroutine(func)
         elif is_generator(func):
             wrapper = self.wrap_generator(func)
@@ -116,18 +114,8 @@ class LineProfiler(CLineProfiler):
         return wrapper
 
     if PY35:
-        def wrap_coroutine(self, func):
-            """ Wrap a Python 3.5 coroutine to profile it.
-            """
-            @functools.wraps(func)
-            async def wrapper(*args, **kwds):
-                self.enable_by_count()
-                try:
-                    result = await func(*args, **kwds)
-                finally:
-                    self.disable_by_count()
-                return result
-            return wrapper
+        import line_profiler_py35
+        wrap_coroutine = line_profiler_py35.wrap_coroutine
 
     def dump_stats(self, filename):
         """ Dump a representation of the data to a file as a pickled LineStats

--- a/line_profiler_py35.py
+++ b/line_profiler_py35.py
@@ -1,0 +1,15 @@
+""" This file is only imported in python 3.5 environments """
+
+def wrap_coroutine(self, func):
+    """
+    Wrap a Python 3.5 coroutine to profile it.
+    """
+    @functools.wraps(func)
+    async def wrapper(*args, **kwds):
+        self.enable_by_count()
+        try:
+            result = await func(*args, **kwds)
+        finally:
+            self.disable_by_count()
+        return result
+    return wrapper

--- a/tests/_test_kernprof_py35.py
+++ b/tests/_test_kernprof_py35.py
@@ -1,0 +1,23 @@
+from kernprof import ContextualProfile
+
+def test_coroutine_decorator(self):
+    async def _():
+        async def c(x):
+            """ A coroutine. """
+            y = x + 10
+            return y
+
+        profile = ContextualProfile()
+        c_wrapped = profile(c)
+        self.assertEqual(c_wrapped.__name__, c.__name__)
+        self.assertEqual(c_wrapped.__doc__, c.__doc__)
+
+        self.assertEqual(profile.enable_count, 0)
+        value = await c_wrapped(10)
+        self.assertEqual(profile.enable_count, 0)
+        self.assertEqual(value, await c(10))
+
+    import asyncio
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_())
+    loop.close()

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -1,6 +1,10 @@
 import unittest
+import sys
 
 from kernprof import ContextualProfile
+
+PY3 = sys.version_info[0] == 3
+PY35 = PY3 and sys.version_info[1] >= 5
 
 
 def f(x):
@@ -72,3 +76,30 @@ class TestKernprof(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(i)
         self.assertEqual(profile.enable_count, 0)
+
+    if PY35:
+        def test_coroutine_decorator(self):
+            async def _():
+                async def c(x):
+                    """ A coroutine. """
+                    y = x + 10
+                    return y
+
+                profile = ContextualProfile()
+                c_wrapped = profile(c)
+                self.assertEqual(c_wrapped.__name__, c.__name__)
+                self.assertEqual(c_wrapped.__doc__, c.__doc__)
+
+                self.assertEqual(profile.enable_count, 0)
+                value = await c_wrapped(10)
+                self.assertEqual(profile.enable_count, 0)
+                self.assertEqual(value, await c(10))
+
+            import asyncio
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(_())
+            loop.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -78,28 +78,8 @@ class TestKernprof(unittest.TestCase):
         self.assertEqual(profile.enable_count, 0)
 
     if PY35:
-        def test_coroutine_decorator(self):
-            async def _():
-                async def c(x):
-                    """ A coroutine. """
-                    y = x + 10
-                    return y
-
-                profile = ContextualProfile()
-                c_wrapped = profile(c)
-                self.assertEqual(c_wrapped.__name__, c.__name__)
-                self.assertEqual(c_wrapped.__doc__, c.__doc__)
-
-                self.assertEqual(profile.enable_count, 0)
-                value = await c_wrapped(10)
-                self.assertEqual(profile.enable_count, 0)
-                self.assertEqual(value, await c(10))
-
-            import asyncio
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(_())
-            loop.close()
-
+        import _test_kernprof_py35
+        test_coroutine_decorator = _test_kernprof_py35.test_coroutine_decorator
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit implement the proper stuff to decorate
the new coroutine style implemented by Python3.5 and their new
statments, making the canonical `profile` decorator compatible.