### PR TITLE
Get support for new 3.5 Python coroutines

### DIFF
--- a/line_profiler.py
+++ b/line_profiler.py
@@ -22,6 +22,7 @@ from _line_profiler import LineProfiler as CLineProfiler
 # Python 2/3 compatibility utils
 # ===========================================================
 PY3 = sys.version_info[0] == 3
+PY35 = PY3 and sys.version_info[1] >= 5
 
 # exec (from https://bitbucket.org/gutworth/six/):
 if PY3:
@@ -40,6 +41,14 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("""exec _code_ in _globs_, _locs_""")
+
+if PY35:
+    import inspect
+    def is_coroutine(f):
+        return inspect.iscoroutinefunction(f)
+else:
+    def is_coroutine(f):
+        return False
 
 # ============================================================
 
@@ -60,7 +69,9 @@ class LineProfiler(CLineProfiler):
         it on function exit.
         """
         self.add_function(func)
-        if is_generator(func):
+        if is_coroutine(func):
+            wrapper = self.wrap_coroutine(func)
+        elif is_generator(func):
             wrapper = self.wrap_generator(func)
         else:
             wrapper = self.wrap_function(func)
@@ -101,6 +112,10 @@ class LineProfiler(CLineProfiler):
                 self.disable_by_count()
             return result
         return wrapper
+
+    if PY35:
+        import line_profiler_py35
+        wrap_coroutine = line_profiler_py35.wrap_coroutine
 
     def dump_stats(self, filename):
         """ Dump a representation of the data to a file as a pickled LineStats

--- a/line_profiler_py35.py
+++ b/line_profiler_py35.py
@@ -1,4 +1,5 @@
 """ This file is only imported in python 3.5 environments """
+import functools
 
 def wrap_coroutine(self, func):
     """

--- a/line_profiler_py35.py
+++ b/line_profiler_py35.py
@@ -1,0 +1,15 @@
+""" This file is only imported in python 3.5 environments """
+
+def wrap_coroutine(self, func):
+    """
+    Wrap a Python 3.5 coroutine to profile it.
+    """
+    @functools.wraps(func)
+    async def wrapper(*args, **kwds):
+        self.enable_by_count()
+        try:
+            result = await func(*args, **kwds)
+        finally:
+            self.disable_by_count()
+        return result
+    return wrapper

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 # Monkeypatch distutils.
 import setuptools
@@ -33,6 +34,11 @@ profile Python applications and scripts either with line_profiler or with the
 function-level profiling tools in the Python standard library.
 """
 
+
+py_modules = ['line_profiler', 'kernprof']
+if sys.version_info > (3, 4):
+    py_modules += ['line_profiler_py35']
+
 setup(
     name = 'line_profiler',
     version = '1.0',
@@ -64,7 +70,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         "Topic :: Software Development",
     ],
-    py_modules = ['line_profiler', 'kernprof'],
+    py_modules = py_modules,
     entry_points = {
         'console_scripts': [
             'kernprof=kernprof:main',

--- a/tests/_test_kernprof_py35.py
+++ b/tests/_test_kernprof_py35.py
@@ -1,0 +1,23 @@
+from kernprof import ContextualProfile
+
+def test_coroutine_decorator(self):
+    async def _():
+        async def c(x):
+            """ A coroutine. """
+            y = x + 10
+            return y
+
+        profile = ContextualProfile()
+        c_wrapped = profile(c)
+        self.assertEqual(c_wrapped.__name__, c.__name__)
+        self.assertEqual(c_wrapped.__doc__, c.__doc__)
+
+        self.assertEqual(profile.enable_count, 0)
+        value = await c_wrapped(10)
+        self.assertEqual(profile.enable_count, 0)
+        self.assertEqual(value, await c(10))
+
+    import asyncio
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_())
+    loop.close()

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -1,6 +1,10 @@
 import unittest
+import sys
 
 from kernprof import ContextualProfile
+
+PY3 = sys.version_info[0] == 3
+PY35 = PY3 and sys.version_info[1] >= 5
 
 
 def f(x):
@@ -72,3 +76,10 @@ class TestKernprof(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(i)
         self.assertEqual(profile.enable_count, 0)
+
+    if PY35:
+        import _test_kernprof_py35
+        test_coroutine_decorator = _test_kernprof_py35.test_coroutine_decorator
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit implement the proper stuff to decorate
the new coroutine style implemented by Python3.5 and their new
statments, making the canonical `profile` decorator compatible.

To hide incompatible 3.5 statements between versions. The idea is be able
to run all Python versions, since 2.X to 3.5 without break the current behaviour.
The Python 3.5 specific code is hidden into private files that will be imported only in
3.5 environments.
