### PR TITLE
Feature: Add 'profile all' option

### DIFF
--- a/tests/test_line_profiler.py
+++ b/tests/test_line_profiler.py
@@ -60,6 +60,18 @@ class TestLineProfiler(unittest.TestCase):
         self.assertEqual(lp.enable_count, 0)
         self.assertEqual(lp.last_time, {})
 
+    def test_enable_profile_all(self):
+        lp = LineProfiler()
+
+        lp.enable_profile_all()
+        lp.enable()
+        value = f(10)
+        lp.disable()
+
+        self.assertEqual(value, f(10))
+        self.assertEqual(len(lp.code_map.keys()), 1)
+        self.assertEqual(len(lp.code_map[f.__code__]), 2)
+
     def test_function_decorator(self):
         profile = LineProfiler()
         f_wrapped = profile(f)


### PR DESCRIPTION
**Content**
Add interface to enable profiling of all executed calls.

**Context**
Github issue: https://github.com/rkern/line_profiler/issues/45
This can be useful when integrating line_profiler with projects that allow profiling without requiring the user to manually specify the target of a profile (eg. https://github.com/iddl/pprofile)

Note: When enabled, this option likely affects the overall performance of the profiler.