### PR TITLE
Fix IPython requirement for Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
         ],
     },
     install_requires = [
-        'IPython>=0.13',
+        "IPython>=0.13 ; python_version >= '3'",
+        "IPython>=0.13,<6 ; python_version < '3'",
     ],
     cmdclass = cmdclass,
 )


### PR DESCRIPTION
IPython recently released IPython 6.0.0, which dropped support for Python 2. Modify setup.py to depend on IPython versions old than 6.0.0 for Python 2 (i.e., those versions which still support Python 2); keep the behavior unchanged for Python 3.

Fixes #89