### PR TITLE
fix encoding error

### DIFF
--- a/line_profiler.py
+++ b/line_profiler.py
@@ -217,7 +217,7 @@ def show_func(filename, start_lineno, func_name, timings, unit, stream=None, str
         nhits, time, per_hit, percent = d.get(lineno, empty)
         txt = template % (lineno, nhits, time, per_hit, percent,
                           line.rstrip('\n').rstrip('\r'))
-        stream.write(txt.encode('utf8'))
+        stream.write(txt.encode(sys.stdout.encoding))
         stream.write("\n")
     stream.write("\n")
 

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -217,7 +217,7 @@ def show_func(filename, start_lineno, func_name, timings, unit, stream=None, str
         nhits, time, per_hit, percent = d.get(lineno, empty)
         txt = template % (lineno, nhits, time, per_hit, percent,
                           line.rstrip('\n').rstrip('\r'))
-        stream.write(txt)
+        stream.write(txt.encode('utf8'))
         stream.write("\n")
     stream.write("\n")
 


### PR DESCRIPTION
`UnicodeEncodeError` will be raised if there are non-ansi characters(e.g. CJK) in the code.
This PR will solve this problem by encoding codes with UTF-8.