### PR TITLE
unset_trace.[ch]: fix prototype warnings

### DIFF
--- a/unset_trace.c
+++ b/unset_trace.c
@@ -2,6 +2,6 @@
 
 #include "Python.h"
 
-void unset_trace() {
+void unset_trace(void) {
     PyEval_SetTrace(NULL, NULL);
 }

--- a/unset_trace.h
+++ b/unset_trace.h
@@ -1,1 +1,1 @@
-void unset_trace();
+void unset_trace(void);


### PR DESCRIPTION
Fix the following warnings with gcc-5.4:

unset_trace.h:1:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void unset_trace();
 ^
unset_trace.c:5:6: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void unset_trace() {
      ^