### PR TITLE
fix installation for python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,11 @@ py_modules = ['line_profiler', 'kernprof']
 if sys.version_info > (3, 4):
     py_modules += ['line_profiler_py35']
 
+if sy.version_info[0] > 2:
+    install_requires = ['IPython>=0.13']
+else:
+    install_requires = ['IPython>=0.13,<6']
+
 setup(
     name = 'line_profiler',
     version = '2.1.1',
@@ -78,8 +83,6 @@ setup(
             'kernprof=kernprof:main',
         ],
     },
-    install_requires = [
-        'IPython>=0.13',
-    ],
+    install_requires=install_requires,
     cmdclass = cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ py_modules = ['line_profiler', 'kernprof']
 if sys.version_info > (3, 4):
     py_modules += ['line_profiler_py35']
 
-if sy.version_info[0] > 2:
+if sys.version_info[0] > 2:
     install_requires = ['IPython>=0.13']
 else:
     install_requires = ['IPython>=0.13,<6']


### PR DESCRIPTION
    for Python 2 the dependency  on IPython must be restricted to
    IPython < 6 as from IPython 6 on only Python 3 is supported.
    This breaks "pip install line_profiler" for Python 2 unless a suitable
    IPython version is already locally installed.