### PR TITLE
fix ZeroDivisionError: float division by zero

### DIFF
--- a/line_profiler.py
+++ b/line_profiler.py
@@ -225,7 +225,7 @@ def show_func(filename, start_lineno, func_name, timings, unit,
         d[lineno] = (nhits,
             '%5.1f' % (time * scalar),
             '%5.1f' % (float(time) * scalar / nhits),
-            '%5.1f' % (100 * time / total_time) )
+            '%5.1f' % (100 * time / (total_time + 1e-6)) )
     linenos = range(start_lineno, start_lineno + len(sublines))
     empty = ('', '', '', '')
     header = template % ('Line #', 'Hits', 'Time', 'Per Hit', '% Time',


### PR DESCRIPTION
While running `python -m line_profiler file_name.py`. I get this minor error which can be fixed with a harmless addition of `1e-6`.

```
Traceback (most recent call last):
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/site-packages/line_profiler.py", line 422, in <module>
    main()
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/site-packages/line_profiler.py", line 419, in main
    show_text(lstats.timings, lstats.unit)
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/site-packages/line_profiler.py", line 259, in show_text
    output_unit=output_unit, stream=stream, stripzeros=stripzeros)
  File "/Users/mark/miniconda3/envs/.env/lib/python3.5/site-packages/line_profiler.py", line 228, in show_func
    '%5.1f' % (100 * time / total_time) )
ZeroDivisionError: float division by zero
```