### PR TITLE
MNT: Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.version_info > (3, 4):
 
 setup(
     name = 'line_profiler',
-    version = '2.1.1',
+    version = '2.1.3.dev',
     author = 'Robert Kern',
     author_email = 'robert.kern@enthought.com',
     description = 'Line-by-line profiler.',


### PR DESCRIPTION
Currently, install from source gives 2.1.1, which is misleading because 2.1.2 is already on PyPI. Changing this to 2.1.3.devN would be clearer?