### PR TITLE
MNT: Set Cython language_level

### DIFF
--- a/_line_profiler.pyx
+++ b/_line_profiler.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 from python25 cimport PyFrameObject, PyObject, PyStringObject
 
 


### PR DESCRIPTION
To get rid of deprecation warning by Cython.