### PR TITLE
MNT: Always compile Cython at build time

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include LICENSE_Python.txt
 include README.rst
 include python25.pxd
 include timers.h
-include _line_profiler.c
+exclude _line_profiler.c
 include unset_trace.h
 recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,18 @@
-import os
 import sys
-
-# Monkeypatch distutils.
-import setuptools
 
 import distutils.errors
 from distutils.core import setup
 from distutils.extension import Extension
-from distutils.log import warn
 
 try:
     from Cython.Distutils import build_ext
     cmdclass = dict(build_ext=build_ext)
     line_profiler_source = '_line_profiler.pyx'
 except ImportError:
-    cmdclass = {}
-    line_profiler_source = '_line_profiler.c'
-    if not os.path.exists(line_profiler_source):
-        raise distutils.errors.DistutilsError("""\
+    raise distutils.errors.DistutilsError("""\
 You need Cython to build the line_profiler from a git checkout, or
 alternatively use a release tarball from PyPI to build it without Cython.""")
-    else:
-        warn("Could not import Cython. "
-             "Using the available pre-generated C file.")
+
 
 long_description = """\
 line_profiler will profile the time individual lines of code take to execute.
@@ -78,6 +68,9 @@ setup(
             'kernprof=kernprof:main',
         ],
     },
+    setup_requires = [
+        'cython',
+    ],
     install_requires = [
         'IPython>=0.13',
     ],


### PR DESCRIPTION
Related issues: #127, #132, #133, #145 

Someone with more setuptools-fu than me should double check on this PR.