### PR TITLE
Support Python 3.7 Generator (PEP 479)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
+dist: xenial
 language: python
 python:
   - "nightly"
-  - "3.7-dev"
-  - "3.6-dev"
+  - "3.8-dev"
+  - "3.7"
   - "3.6"
   - "3.5"
-  - "3.4"
-  - "3.3"
   - "2.7"
 matrix:
   fast_finish: true
   allow_failures:
     - python: "nightly"
-    - python: "3.7-dev"
-    - python: "3.6-dev"
+    - python: "3.8-dev"
 install:
   - pip install --install-option='--no-cython-compile' Cython
   - pip install -r dev_requirements.txt

--- a/kernprof.py
+++ b/kernprof.py
@@ -102,6 +102,8 @@ class ContextualProfile(Profile):
                 self.enable_by_count()
                 try:
                     item = g.send(input)
+                except StopIteration:
+                    return
                 finally:
                     self.disable_by_count()
                 input = (yield item)

--- a/kernprof.py
+++ b/kernprof.py
@@ -94,6 +94,8 @@ class ContextualProfile(Profile):
             self.enable_by_count()
             try:
                 item = next(g)
+            except StopIteration:
+                return
             finally:
                 self.disable_by_count()
             input = (yield item)

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -92,6 +92,8 @@ class LineProfiler(CLineProfiler):
             self.enable_by_count()
             try:
                 item = next(g)
+            except StopIteration:
+                return
             finally:
                 self.disable_by_count()
             input = (yield item)

--- a/line_profiler.py
+++ b/line_profiler.py
@@ -100,6 +100,8 @@ class LineProfiler(CLineProfiler):
                 self.enable_by_count()
                 try:
                     item = g.send(input)
+                except StopIteration:
+                    return
                 finally:
                     self.disable_by_count()
                 input = (yield item)


### PR DESCRIPTION
resolves #152 

PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions. 