### PR TITLE
Travis CI: Drop EOL versions on Python and add 3.7 and 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   allow_failures:
     - python: "nightly"
     - python: "3.8-dev"
+    - python: "3.7"
 install:
   - pip install --install-option='--no-cython-compile' Cython
   - pip install -r dev_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: python
+dist: xenial  # required for Python >= 3.7 on Travis CI
 python:
   - "nightly"
-  - "3.7-dev"
-  - "3.6-dev"
+  - "3.8-dev"
+  - "3.7"
   - "3.6"
   - "3.5"
-  - "3.4"
-  - "3.3"
   - "2.7"
 matrix:
   fast_finish: true
   allow_failures:
     - python: "nightly"
-    - python: "3.7-dev"
-    - python: "3.6-dev"
+    - python: "3.8-dev"
 install:
   - pip install --install-option='--no-cython-compile' Cython
   - pip install -r dev_requirements.txt


### PR DESCRIPTION
#153 or similar is __required__ to be compatible with Python 3.7.