### PR TITLE
Add a pyproject.toml file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include python25.pxd
 include timers.h
 include _line_profiler.c
 include unset_trace.h
+include pyproject.toml
 recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.0", "wheel", "Cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This makes this library ready to install with [PEP 517](https://www.python.org/dev/peps/pep-0517/) / [PEP 518](https://www.python.org/dev/peps/pep-0518/).

I am not sure if this solves the problem referred to in the README.md, but I will say that `pip install .` on a git checkout (or presumably from a source distribution) will fail without this file, whereas `pip install .` will work just fine with it.

It would also be nice if the next release could have some wheels added for it, particularly for platforms that are unlikely to have a compiler installed already, like Windows.